### PR TITLE
Update CustomServiceProvider.php

### DIFF
--- a/examples/postgres/src/CustomServiceProvider.php
+++ b/examples/postgres/src/CustomServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace AbuseIO\Findcontact\Custom;
+namespace AbuseIO\FindContact\Custom;
 
 use Illuminate\Support\ServiceProvider;
 


### PR DESCRIPTION
Camel cased the namespace even though namespaces in PHP are not case sensitive (I believe) but it can confuse autoloaders.